### PR TITLE
:bathtub: Add ruff precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.12.7
+  hooks:
+    # Run the linter.
+    - id: ruff-check
+      args: [ --fix ]
+    # Run the formatter.
+    - id: ruff-format


### PR DESCRIPTION
This PR sets up ruff as the linter / formatter.

1. run `uv pip install --system pre-commit` to install `pre-commit`
2. run `pre-commit install` to hook pre commits (only ruff for now)

From now on:
 - each time you commit, `ruff` will attempt to format the affected files
 - if formating has no effect (no diff) then your commit will be commited
 - otherwise commit will be prevented and you'll need to add changes induced by ruff formating to your commit to comply.

It's also a nice thing to setup this hook directly on your editor so formating occurs on save. 